### PR TITLE
Upload bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get a local copy up and running, follow these steps
    - Create a .env file in the root directory of the project
    - Add the path for where you want script files to be stored after they have been uploaded by the user
      ```js
-     UPLOADPATH =/example/path/scriptUploads;
+     UPLOADPATH=/example/path/scriptUploads
      ```
    - Add a database uri for your postgres database
      ```

--- a/src/components/Upload.jsx
+++ b/src/components/Upload.jsx
@@ -34,7 +34,15 @@ const Upload = ({ setCurrentScript, titles, setTitles }) => {
     })
       .then((response) => {
         if (response.status === 409) {
-          throw new Error('script already exists');
+          throw new Error('Script title already exists');
+        }
+        if (response.status === 452) {
+          throw new Error('Could not find a title, potentially invalid file type');
+        }
+        if (response.status === 500) {
+          throw new Error(
+            "File was not uploaded. Make sure the file name doesn't start with an underscore and only uses numbers, letters, and these symbols: ' . _ - "
+          );
         }
         return response.json();
       })
@@ -47,12 +55,7 @@ const Upload = ({ setCurrentScript, titles, setTitles }) => {
         setFile(null);
       })
       .catch((err) => {
-        if (err.message === 'script already exists') {
-          setUploadMessage({ message: 'That script title already exists.', error: true });
-        } else {
-          setUploadMessage({ message: 'File was not uploaded. Try again.', error: true });
-          console.error(`error: ${err} when uploading script`);
-        }
+        setUploadMessage({ message: err.message, error: true });
       });
   };
 

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 
 const scriptController = require('./controllers/scriptController.js');
 const actorController = require('./controllers/actorController.js');
+const ServerError = require('./utils.js');
 
 const app = express();
 
@@ -58,7 +59,7 @@ app.use((err, req, res, next) => {
     status: 500,
     message: 'Express error handler caught unknown middleware error',
   };
-  const errorObj = Object.assign({}, defaultErr, err);
+  const errorObj = err instanceof ServerError ? err : defaultErr;
   console.log(errorObj.log);
   return res.status(errorObj.status).json(errorObj.message);
 });

--- a/src/services/scriptParser.js
+++ b/src/services/scriptParser.js
@@ -1,3 +1,4 @@
+const ServerError = require('./utils');
 /*
 TODO: Add handling for other script formats 
 
@@ -17,7 +18,7 @@ function parseTitle(scriptText) {
     return matches[1]; // Return just the title itself
   }
 
-  throw new Error('Could not identify a title in the script');
+  throw new ServerError(452, 'Could not identify a title in the script');
 }
 
 function parseLines(scriptText) {
@@ -30,7 +31,6 @@ function parseCharacters(scriptText) {
   const characters = {};
   // loop through the script and create character objects
   for (let lineChunk of lineChunks) {
-
     // A line chunk always starts with the character name followed by a period
     const name = lineChunk.split('.')[0];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+class ServerError extends Error {
+  constructor(status, message, log) {
+    super(message);
+    if (!log) {
+      this.log = message;
+    } else {
+      this.log = log;
+    }
+    this.status = status;
+  }
+}
+
+module.exports = ServerError;


### PR DESCRIPTION
Previously when an error for the filename was thrown it would create a script button for it, this fixes that by checking in the Upload component for a 500 error and displaying an error message.

Also fixes the issue of uploading a file that isn't a script (defined by not having a Title that the parser can find). If a title isn't found, the file is deleted. This is so we aren't storing photos or files that aren't valid scripts. This also throws a 500 error but has a more helpful error message for the user.