### PR TITLE
Fixes bug where the Home page tries to get characters for a null script

### DIFF
--- a/src/components/CharacterAssignment.jsx
+++ b/src/components/CharacterAssignment.jsx
@@ -18,9 +18,13 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
 
   // When the current script changes create a column for each actor and populate it with the assigned characters
   useEffect(() => {
-    (async () => {
-      await setupColumns(currentScriptId, actors);
-    })();
+    // Checking if we have a script prevents it from doing all the work to get the data and create the columns when
+    // the component won't be rendered anyway
+    if (currentScriptId) {
+      (async () => {
+        await setupColumns(currentScriptId, actors);
+      })();
+    }
   }, [currentScriptId]);
 
 


### PR DESCRIPTION
Adds a currentScript check to the useEffect the initially creates the columns. This prevents the unnecessary data fetch and column creation since the component won't be rendered anyway