### PR TITLE
Adds JSdoc documentation to most files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env
 
 node_modules
+docs
 public/main.js
 public/main.js.LICENSE.txt
 scriptUploads

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .env
 
 node_modules
-docs
+build
 public/main.js
 public/main.js.LICENSE.txt
 scriptUploads

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,22 @@
+{
+  "opts": {
+    "template": "node_modules/docdash"
+  },
+  "plugins": [
+    "plugins/markdown"
+  ],
+  "docdash": {
+    "static": true,
+    "sort": true,
+    "search": true,
+    "collapse": true,
+    "typedefs": true,
+    "removeQuotes": "none",
+    "scripts": []
+  },
+  "templates": {
+    "default": {
+      "useLongnameInNav": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,12 @@
         "@babel/runtime": "^7.20.6",
         "babel-loader": "^9.1.0",
         "concurrently": "^7.6.0",
+        "docdash": "^2.0.1",
         "eslint": "^8.29.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-jest": "^27.1.6",
+        "jsdoc": "^4.0.2",
         "nodemon": "^2.0.20",
         "prettier": "^2.8.4",
         "webpack": "^5.75.0",
@@ -1990,6 +1992,18 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
+      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -2173,6 +2187,28 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -3193,6 +3229,18 @@
         }
       ]
     },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3726,6 +3774,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/docdash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/docdash/-/docdash-2.0.1.tgz",
+      "integrity": "sha512-mkBhkeMyMwGV4YIdA7S4dIC25ENrfU/ZBfyTs/MXj/HUewW/dtx44xoho4PttCOMsqxlcghzfj8HRlam5QiSoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jsdoc/salty": "^0.2.1"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3782,6 +3839,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/envinfo": {
@@ -5654,6 +5720,53 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
+      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^12.2.3",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5705,6 +5818,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "node_modules/launch-editor": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
@@ -5726,6 +5848,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
       }
     },
     "node_modules/loader-runner": {
@@ -5811,6 +5942,50 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -5944,14 +6119,15 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -5975,6 +6151,17 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/multicast-dns": {
@@ -7019,6 +7206,15 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -8013,6 +8209,12 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8032,6 +8234,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -8195,9 +8403,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.83.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.83.1.tgz",
-      "integrity": "sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==",
+      "version": "5.84.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.84.0.tgz",
+      "integrity": "sha512-XezNK3kwJq6IyeoZmZ1uEqQs+42nTqIi4jYM/YjLwaJedUC1N3bwnCC0+UcnHJPfqWX0kGrQnMIvZZyWYaIZrA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -8206,10 +8414,10 @@
         "@webassemblyjs/wasm-edit": "^1.11.5",
         "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.7.6",
+        "acorn-import-assertions": "^1.9.0",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.14.0",
+        "enhanced-resolve": "^5.14.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -8591,6 +8799,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -10012,6 +10226,15 @@
         }
       }
     },
+    "@jsdoc/salty": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
+      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -10183,6 +10406,28 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "peer": true
+    },
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "dev": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "dev": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -10978,6 +11223,15 @@
       "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
       "dev": true
     },
+    "catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -11383,6 +11637,15 @@
         "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
+    "docdash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/docdash/-/docdash-2.0.1.tgz",
+      "integrity": "sha512-mkBhkeMyMwGV4YIdA7S4dIC25ENrfU/ZBfyTs/MXj/HUewW/dtx44xoho4PttCOMsqxlcghzfj8HRlam5QiSoQ==",
+      "dev": true,
+      "requires": {
+        "@jsdoc/salty": "^0.2.1"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -11428,6 +11691,12 @@
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
       }
+    },
+    "entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true
     },
     "envinfo": {
       "version": "7.8.1",
@@ -12802,6 +13071,46 @@
         "argparse": "^2.0.1"
       }
     },
+    "js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "jsdoc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
+      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^12.2.3",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -12838,6 +13147,15 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "launch-editor": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
@@ -12856,6 +13174,15 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
       }
     },
     "loader-runner": {
@@ -12925,6 +13252,38 @@
           "dev": true
         }
       }
+    },
+    "markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "requires": {}
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -13022,12 +13381,10 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -13047,6 +13404,16 @@
         "object-assign": "^4.1.1",
         "type-is": "^1.6.4",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
       }
     },
     "multicast-dns": {
@@ -13815,6 +14182,15 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
+    "requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -14572,6 +14948,12 @@
       "dev": true,
       "peer": true
     },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -14588,6 +14970,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -14704,9 +15092,9 @@
       }
     },
     "webpack": {
-      "version": "5.83.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.83.1.tgz",
-      "integrity": "sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==",
+      "version": "5.84.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.84.0.tgz",
+      "integrity": "sha512-XezNK3kwJq6IyeoZmZ1uEqQs+42nTqIi4jYM/YjLwaJedUC1N3bwnCC0+UcnHJPfqWX0kGrQnMIvZZyWYaIZrA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -14715,10 +15103,10 @@
         "@webassemblyjs/wasm-edit": "^1.11.5",
         "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.7.6",
+        "acorn-import-assertions": "^1.9.0",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.14.0",
+        "enhanced-resolve": "^5.14.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -14966,6 +15354,12 @@
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
       "requires": {}
+    },
+    "xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "./dev.sh",
     "build": "NODE_ENV=production webpack . && podman image build -t play-reading .",
     "front": "NODE_ENV=development webpack-dev-server --open",
-    "back": "nodemon src/server.js"
+    "back": "nodemon src/server.js",
+    "jsdoc": "jsdoc -a all -c jsdoc.json -R README.md -r ./src/ -d docs/jsdoc"
   },
   "nodemonConfig": {
     "ignore": [
@@ -42,10 +43,12 @@
     "@babel/runtime": "^7.20.6",
     "babel-loader": "^9.1.0",
     "concurrently": "^7.6.0",
+    "docdash": "^2.0.1",
     "eslint": "^8.29.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jest": "^27.1.6",
+    "jsdoc": "^4.0.2",
     "nodemon": "^2.0.20",
     "prettier": "^2.8.4",
     "webpack": "^5.75.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "NODE_ENV=production webpack . && podman image build -t play-reading .",
     "front": "NODE_ENV=development webpack-dev-server --open",
     "back": "nodemon src/server.js",
-    "jsdoc": "jsdoc -a all -c jsdoc.json -R README.md -r ./src/ -d docs/jsdoc"
+    "jsdoc": "jsdoc -a all -c jsdoc.json -R README.md -r ./src/ -d build/docs/jsdoc"
   },
   "nodemonConfig": {
     "ignore": [

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -12,19 +12,21 @@ import CharacterAssignment from './components/CharacterAssignment';
 /**
  * React Router loader for the Home page, load the actor names and script titles
  * @param {URLSearchParams} params The URL parameter from React Router
- * @param {string} params.scriptId The current script ID
- * @return {Promise<loaderActorsScriptsScriptId>}
+ * @param {string} params.scriptId The script ID
+ * @returns {Promise<Object>} Either returns the loaded data or empty objects and the Script ID.
+ * @returns {Array.<Actor>|{}} Object.loadedActors
+ * @returns {Array.<Script>|{}} Object.loadedScripts Array of Script objects that have an id and title
+ * @returns {scriptId: String} Object.scriptId
  */
 // Load the actor names and script titles on page load
 export async function loader({ params }) {
   const scriptId = params.scriptId;
   const [loadedActors, loadedScripts] = await Promise.all([getActors(), getScriptTitles()]);
   if (loadedActors.success && loadedScripts.success) {
-    return { loadedActors: loadedActors.data, loadedScripts: loadedScripts.data, scriptId };
+    return {loadedActors: loadedActors.data, loadedScripts: loadedScripts.data, scriptId};
   } else {
-    console.error(loadedActors.data, loadedScripts.data);
-    // We return empty objects when there is an error because it makes it easier to trace back the error
-    return { loadedScripts: {}, loadedActors: {}, scriptId };
+    console.error(loadedActors.data, loadedScripts.data, scriptId);
+    return {loadedActors: {}, loadedScripts: {}, scriptId};
   }
 }
 

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -9,7 +9,12 @@ import Header from './components/Header';
 import { getActors, getScriptTitles } from './components/api';
 import CharacterAssignment from './components/CharacterAssignment';
 
-
+/**
+ * React Router loader for the Home page, load the actor names and script titles
+ * @param {URLSearchParams} params The URL parameter from React Router
+ * @param {string} params.scriptId The current script ID
+ * @return {Promise<loaderActorsScriptsScriptId>}
+ */
 // Load the actor names and script titles on page load
 export async function loader({ params }) {
   const scriptId = params.scriptId;
@@ -23,7 +28,11 @@ export async function loader({ params }) {
   }
 }
 
-
+/**
+ * Component containing the entire home page, linked to from the Header button
+ * @return {JSX.Element} React Component Home
+ * @constructor
+ */
 const Home = () => {
   // With the loaded data, set the initial state for the actors and script list
   const { loadedActors, loadedScripts, scriptId } = useLoaderData();

--- a/src/components/ActorList.jsx
+++ b/src/components/ActorList.jsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 import { deleteActor } from './api';
 
+/**
+ * Actor list component that displays and allows for deletion of actors
+ * @param {Array.<Actor>} actors Actors from state
+ * @param {function} setActors Setter for actors state
+ * @return {JSX.Element} React Component ActorList
+ * @constructor
+ */
 const ActorList = ({ actors, setActors }) => {
   const [deleteError, setDeleteError] = useState('');
 

--- a/src/components/AddActor.jsx
+++ b/src/components/AddActor.jsx
@@ -1,11 +1,19 @@
 import React, { useState } from 'react';
 import { newActor } from './api';
 
+/**
+ * Input to add a new actor
+ * @param {Array.<Actor>} actors Actors from state
+ * @param {function} setActors Setter for actors state
+ * @return {JSX.Element} React Component AddActor
+ * @constructor
+ */
 const AddActor = ({ actors, setActors }) => {
   const [addActorError, setAddActorError] = useState('');
 
   const newActorHandler = async (e) => {
     e.preventDefault();
+
     const name = e.target.elements.actorName.value;
     // Add the new actor values to the database
     const result = await newActor(name);

--- a/src/components/Character.jsx
+++ b/src/components/Character.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 
-// Individual draggable character card with character data.
+/**
+ * Individual draggable character card with character data.
+ * @param {Character} character The character's data
+ * @param {number} index Number for react-dnd-beautiful to use to track drag and drop location
+ * @return {JSX.Element} Draggable React Component Character
+ * @constructor
+ */
+
 const Character = ({ character, index }) => {
   // Removes the drop animation so there isn't a delay between the character being dropped and the line count updating
   function getStyle(style, snapshot) {

--- a/src/components/CharacterAssignment.jsx
+++ b/src/components/CharacterAssignment.jsx
@@ -221,7 +221,6 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
 
 };
 
-/** Column Class */
 class Column {
   /**
    * @param {string} id id used for drag and drop reference

--- a/src/components/CharacterAssignment.jsx
+++ b/src/components/CharacterAssignment.jsx
@@ -17,7 +17,6 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
   const [columns, setColumns] = useState({
     'unassignedCharacters': new Column('unassignedCharacters', 'Unassigned Characters', characters)
   });
-  /** @module CharacterAssignment */
 
   // When the current script changes create a column for each actor and populate it with the assigned characters
   useEffect(() => {
@@ -36,22 +35,6 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
     updateActorColumns(actors);
   }, [actors]);
 
-  /**
-   * Column constructor
-   * @param {string} id id used for drag and drop reference
-   * @param {string} title Column title that will be displayed
-   * @param {object} characters Contains Character objects indexed by their id
-   * @constructor
-   */
-  function Column(id, title, characters) {
-    this.id = id;
-    this.title = title;
-    this.characterIds = [];
-    this.getLineCount = function() {
-      if (characters === null) return;
-      return this.characterIds.reduce((acc, curr) => acc + characters[curr].lineCount, 0);
-    };
-  }
 
   /** @function setupColumns
    * @description Create the actor columns and populate them with the assigned characters.
@@ -207,7 +190,6 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
     }
   };
 
-
   // No script is selected, don't bother rendering the component
   if (!currentScriptId) {
     return;
@@ -238,5 +220,23 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
   );
 
 };
+
+/** Column Class */
+class Column {
+  /**
+   * @param {string} id id used for drag and drop reference
+   * @param {string} title Column title that will be displayed
+   * @param {object} characters Contains Character objects indexed by their id
+   */
+  constructor(id, title, characters) {
+    this.id = id;
+    this.title = title;
+    this.characterIds = [];
+    this.getLineCount = function() {
+      if (characters === null) return;
+      return this.characterIds.reduce((acc, curr) => acc + characters[curr].lineCount, 0);
+    };
+  }
+}
 
 export default CharacterAssignment;

--- a/src/components/CharacterAssignment.jsx
+++ b/src/components/CharacterAssignment.jsx
@@ -3,13 +3,21 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import { getCharacters, assignCharacter } from './api';
 import DropColumn from './DropColumn';
 
-// Entire Drag and Drop context for assigning characters to actors
+/**
+ * Drag and Drop context for assigning characters to actors
+ * @param {Array.<Actor>} actors Actors from state
+ * @param {string} currentScriptId The ID for the current script
+ * @return {JSX.Element | undefined} DragDropContext React Component CharacterAssignment.
+ * We allow undefined return for when there is no current script, so we don't return the component.
+ * @constructor
+ */
 const CharacterAssignment = ({ actors, currentScriptId }) => {
   const [characters, setCharacters] = useState({});
   const [columnOrder, setColumnOrder] = useState([]);
   const [columns, setColumns] = useState({
     'unassignedCharacters': new Column('unassignedCharacters', 'Unassigned Characters', characters)
   });
+  /** @module CharacterAssignment */
 
   // When the current script changes create a column for each actor and populate it with the assigned characters
   useEffect(() => {
@@ -45,9 +53,9 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
     };
   }
 
-  /**
-   * Create the actor columns and populate them with the assigned characters.
-   * Update state with the new columns, columnOrder, and characters
+  /** @function setupColumns
+   * @description Create the actor columns and populate them with the assigned characters.
+   *  Update state with the new columns, columnOrder, and characters
    * @param {string} currentScriptId Stringified numerical script ID
    * @param {array} actors Array of actor objects
    */
@@ -64,8 +72,8 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
     }
   };
 
-  /**
-   * Put the characters in the appropriate actor columns
+  /** @function assignInitialCharacters
+   * @description Put the characters in the appropriate actor columns
    * @param  {object} columns Object of actor column objects, no assigned characters
    * @param {object} characters  Contains Character objects indexed by their id
    * @returns {object} Object of actor column objects, now updated with assigned characters
@@ -82,8 +90,8 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
     return columns;
   };
 
-  /**
-   * Create the actor columns, all empty at this stage
+  /** @function createInitialActorColumns
+   * @description Create the actor columns, all empty at this stage
    * @param {array} actors Array of objects with properties of name and id
    * @param {object} characters  Contains Character objects indexed by their id
    * @returns {object} Object of actor column objects and array of actor IDs
@@ -99,8 +107,8 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
     });
     return { newColumns: columns, newColumnOrder: actorIds };
   };
-  /**
-   * Update the actor columns when the number of actors changes and set the new column values and order
+  /** @function updateActorColumns
+   * @description Update the actor columns when the number of actors changes and set the new column values and order
    * @param actors Array of objects with properties of name and id
    */
   const updateActorColumns = (actors) => {
@@ -118,8 +126,8 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
 
   };
 
-  /**
-   * Add a new actor column by checking that each actor in our list has a column,
+  /** @function addActorColumn
+   * @description Add a new actor column by checking that each actor in our list has a column,
    *  and creating one when a column isn't found with that actor's id
    * @param actors Array of objects with properties of name and id
    * @param columns Object containing column objects with properties of id, title, characterIds, and lineCount
@@ -135,8 +143,8 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
     return { newColumns: columns, newColumnOrder: columnOrder };
   };
 
-  /**
-   * Remove an actor column by going through the columns and checking if each column matches up with an actor,
+  /** @function removeActorColumn
+   * @description Remove an actor column by going through the columns and checking if each column matches up with an actor,
    *  if it doesn't, and it isn't the unassigned column, remove the column.
    * @param actors Array of objects with properties of name and id
    * @param columns Object containing column objects with properties of id, title, characterIds, and lineCount
@@ -158,8 +166,8 @@ const CharacterAssignment = ({ actors, currentScriptId }) => {
   };
 
 
-  /**
-   * Remove a character from its source column and adds it to its destination column,
+  /** @function onDragEnd
+   * @description Remove a character from its source column and adds it to its destination column,
    *  update the database with the assignment info, and set state to reflect the changes.
    * @param result React-beautiful-dnd set parameter
    */

--- a/src/components/DropColumn.jsx
+++ b/src/components/DropColumn.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import Character from './Character.jsx';
 import { Droppable } from 'react-beautiful-dnd';
 
-//Actor or unassigned column. Droppable so the Draggable Characters can be dropped on it
+/**
+ * Actor or unassigned column Droppable component.
+ * @param {Column} column Individual actor|unassigned column
+ * @param {Array.<Character>} characterList All the characters assigned to this column
+ * @return {JSX.Element} Droppable React Component DropColumn
+ * @constructor
+ */
 const DropColumn = ({ column, characterList }) => {
   return (
     <div className='dropContainer' style={{ height: 'fit-content' }}>

--- a/src/components/DropColumn.jsx
+++ b/src/components/DropColumn.jsx
@@ -4,7 +4,7 @@ import { Droppable } from 'react-beautiful-dnd';
 
 /**
  * Actor or unassigned column Droppable component.
- * @param {Column} column Individual actor|unassigned column
+ * @param {Column} column Individual actor | unassigned column
  * @param {Array.<Character>} characterList All the characters assigned to this column
  * @return {JSX.Element} Droppable React Component DropColumn
  * @constructor

--- a/src/components/ErrorPage.jsx
+++ b/src/components/ErrorPage.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { useRouteError } from 'react-router-dom';
 
-
+/**
+ * Component for the default error page for React Router
+ * @return {JSX.Element} React Component ErrorPage
+ * @constructor
+ */
 const ErrorPage = () => {
   const error = useRouteError();
   console.error(error);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+/**
+ * Header component that displays the page name and acts as the 'Home' button
+ * @param {string} currentScriptId The ID for the current script
+ * @return {JSX.Element} React Component Header
+ * @constructor
+ */
 const Header = ({ currentScriptId }) => {
-
 
   return (
     <div>

--- a/src/components/ReadingDots.jsx
+++ b/src/components/ReadingDots.jsx
@@ -1,16 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { postPosition } from './api';
 
-// Generate a unique and stable hue based on the actor name
-function getActorHue(actor) {
-  let input = 0;
-  for (const char of actor) {
-    input += char.charCodeAt(0);
-  }
-
-  return input % 360;
-}
-
+/**
+ * Component containing all the progress tracking reading dots on the script page
+ * @param {Array.<Actor>} actors Actors from state
+ * @param {Actor} currentActor Current selected actor from state
+ * @param {string} currentScriptId The Id for the current script from state
+ * @return {JSX.Element} React Component ReadingDots
+ * @constructor
+ */
 const ReadingDots = ({ actors, currentActor, currentScriptId }) => {
   const [dots, setDots] = useState({});
   const refDots = useRef({});
@@ -119,5 +117,19 @@ const ReadingDots = ({ actors, currentActor, currentScriptId }) => {
     </div>
   );
 };
+
+/**
+ * Generate a unique and stable hue based on the actor name
+ * @param {string} actor The actor's name
+ * @return {number} Total value of the character's in the actor's name, capped at 360 with wrap around.
+ */
+function getActorHue(actor) {
+  let input = 0;
+  for (const char of actor) {
+    input += char.charCodeAt(0);
+  }
+
+  return input % 360;
+}
 
 export default ReadingDots;

--- a/src/components/Script.jsx
+++ b/src/components/Script.jsx
@@ -6,28 +6,22 @@ import Header from './Header';
 import { getActors, getScript } from './api';
 
 /**
- * @typedef loaderActorsScriptsScriptId
- * @property {Array.<Actor> | {}} loadedActors All the actor data retrieved from the database
- * @property {Array.string | {}} loadedScript The full script
- * @property {string} currentScriptId The ID for the current script
- */
-
-/**
  * React Router loader for the Script page, load the actor names and script titles
  * @param {URLSearchParams} params The URL parameter from React Router
- * @param {string} params.scriptId The current script ID selected on the Home page
- * @return {Promise<loaderActorsScriptsScriptId>}
+ * @param {string} params.scriptId The script ID
+ * @returns {Promise<Object>} Either returns the loaded data or empty objects and the Script ID.
+ * @returns {Array.<Actor>|{}} Object.loadedActors
+ * @returns {Array.<string>|{}} Object.loadedScript The entire script text chunked into sections
+ * @returns {scriptId: String} Object.scriptId
  */
 export async function loader({ params }) {
-  const currentScriptId = params.scriptId;
-  const [loadedActors, loadedScript] = await Promise.all(
-    [getActors(), getScript(currentScriptId)]);
+  const scriptId = params.scriptId;
+  const [loadedActors, loadedScript] = await Promise.all([getActors(), getScript(scriptId)]);
   if (loadedActors.success && loadedScript.success) {
-    return { loadedActors: loadedActors.data, loadedScript: loadedScript.data, currentScriptId };
+    return {loadedActors: loadedActors.data, loadedScript: loadedScript.data, scriptId};
   } else {
-    console.error(loadedActors.data, loadedScript.data);
-    // We return empty objects when there is an error because it makes it easier to trace back the error
-    return { loadedScript: {}, loadedActors: {}, currentScriptId };
+    console.error(loadedActors.data, loadedScript.data, scriptId);
+    return {loadedActors: {}, loadedScript: {}, scriptId};
   }
 }
 

--- a/src/components/Script.jsx
+++ b/src/components/Script.jsx
@@ -5,7 +5,19 @@ import ReadingDots from './ReadingDots';
 import Header from './Header';
 import { getActors, getScript } from './api';
 
-// Load the actor names and script titles on page load. Returns currentScriptId id to pass on.
+/**
+ * @typedef loaderActorsScriptsScriptId
+ * @property {Array.<Actor> | {}} loadedActors All the actor data retrieved from the database
+ * @property {Array.string | {}} loadedScript The full script
+ * @property {string} currentScriptId The ID for the current script
+ */
+
+/**
+ * React Router loader for the Script page, load the actor names and script titles
+ * @param {URLSearchParams} params The URL parameter from React Router
+ * @param {string} params.scriptId The current script ID selected on the Home page
+ * @return {Promise<loaderActorsScriptsScriptId>}
+ */
 export async function loader({ params }) {
   const currentScriptId = params.scriptId;
   const [loadedActors, loadedScript] = await Promise.all(
@@ -19,6 +31,11 @@ export async function loader({ params }) {
   }
 }
 
+/**
+ * Component containing the entire script page, linked to from the ScriptNav component 'Open Script' button
+ * @return {JSX.Element} React Component Script
+ * @constructor
+ */
 const Script = () => {
   const { loadedActors, loadedScript, currentScriptId } = useLoaderData();
   const [currentActor, setCurrentActor] = useState({});
@@ -28,6 +45,7 @@ const Script = () => {
   const lineChunks = [];
   const characterSet = new Set(currentCharacters);
 
+  // NOTE: Currently using Object.entries for performance purposes, potentially look into benchmarking other iterative approaches
   for (let [i, lineChunk] of Object.entries(loadedScript)) {
     // checks if the character name for this chunk is the name of a character assigned to the current actor
     // remove the dot because some scripts have a dot after the name of the character, ie VIOLA.
@@ -35,8 +53,7 @@ const Script = () => {
     if (characterSet.has(name)) {
       lineChunks.push(<pre className='currentActor' key={`chk-${i}`}>{lineChunk}</pre>);
     } else {
-      lineChunks.push(<pre key={`chk-${i}`}>{lineChunk}</pre>
-      );
+      lineChunks.push(<pre key={`chk-${i}`}>{lineChunk}</pre>);
     }
   }
 

--- a/src/components/ScriptNav.jsx
+++ b/src/components/ScriptNav.jsx
@@ -2,6 +2,15 @@ import React, { useState } from 'react';
 import { deleteScript } from './api';
 import { Link } from 'react-router-dom';
 
+/**
+ * Script selection component with buttons for each script title and ability to delete scripts
+ * @param {string} currentScriptId Current Script ID in state
+ * @param {function} setCurrentScriptId Setter for currentScriptId
+ * @param {Array.<Script>} scripts Script data in state
+ * @param {function} setScripts Setter for scripts
+ * @return {JSX.Element} React Component ScriptNav
+ * @constructor
+ */
 const ScriptNav = ({ currentScriptId, setCurrentScriptId, scripts, setScripts }) => {
   const [scriptError, setScriptError] = useState('');
 

--- a/src/components/Upload.jsx
+++ b/src/components/Upload.jsx
@@ -1,6 +1,14 @@
 import React, { useState } from 'react';
 import { uploadScript } from './api';
 
+/**
+ * Upload script component that takes a file input and displays pertinent errors
+ * @param {function} setCurrentScriptId Setter for currentScriptId state
+ * @param {Array.<Script>} scripts Script data objects
+ * @param {function} setScripts Setter for scripts
+ * @return {JSX.Element} React Component Upload
+ * @constructor
+ */
 const Upload = ({ setCurrentScriptId, scripts, setScripts }) => {
   const MAX_FILESIZE_BYTES = 50 * 1024 * 1024; // 50MB If updating, change constant in scriptController.js too
   const [file, setFile] = useState();
@@ -27,6 +35,7 @@ const Upload = ({ setCurrentScriptId, scripts, setScripts }) => {
     // set the file as Form Data and send it to the server
     const formData = new FormData();
     formData.append('scriptFormField', file);
+    console.log(formData)
 
     // Upload the script and display any error messages
     const result = await uploadScript(formData);

--- a/src/components/actorScriptButton.jsx
+++ b/src/components/actorScriptButton.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import { getCurrentActorCharacters } from './api';
 
+/**
+ * Actor button on the script page, allows for selection of the current actor
+ * @param {Actor} actor The actor associated with this button
+ * @param {function} setCurrentActor Setter for currentActor state
+ * @param {function} setCurrentCharacters Setter for currentCharacters state
+ * @param {string} currentScriptId The ID for the current script
+ * @return {JSX.Element} React Component ActorScriptButton
+ * @constructor
+ */
 const ActorScriptButton = ({ actor, setCurrentActor, setCurrentCharacters, currentScriptId }) => {
   // on change, change the value of current actor
   const setActorHandler = async () => {

--- a/src/components/actorScriptNav.jsx
+++ b/src/components/actorScriptNav.jsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import ActorScriptButton from './actorScriptButton';
 
+/**
+ * Component containing all the actor buttons on the script page
+ * @param {Array.<Actor>} actors Actors from state
+ * @param {function} setCurrentActor Setter for currentActor state
+ * @param {function} setCurrentCharacters Setter for currentCharacters state
+ * @param {string} currentScriptId The ID for the current script
+ * @return {JSX.Element} React Component ActorScriptNav
+ * @constructor
+ */
+
 const ActorScriptNav = ({ actors, setCurrentActor, setCurrentCharacters, currentScriptId }) => {
   const buttons = [];
   for (let actor of actors) {

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -21,7 +21,6 @@ async function getActors() {
  * @return {Promise<ApiResponse>}
  */
 async function deleteActor(id) {
-  console.log(typeof id)
   return await apiCall('DELETE', `actors/${id}`);
 };
 
@@ -101,7 +100,6 @@ async function deleteScript(deleteId) {
  * @return {Promise<{success: boolean, data: any}>}
  */
 async function uploadScript(formData) {
-  console.log(typeof formData)
   const response = await fetch('/api/script', { method: 'POST', body: formData })
   if (response.ok){
     return {

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -1,24 +1,66 @@
+/**
+ * @typedef ApiResponse
+ * @property {boolean} success Whether or not the api call went through
+ * @property {any} data The data from the successful call, or an error message for a failed call
+ * @property {number} status The status for a failed call
+ */
+
+/** @module apiCalls */
+
+/**
+ * gets all actors
+ * @return {Promise<ApiResponse>}
+ */
 async function getActors() {
   return await apiCall('GET', 'actors');
 }
 
+/**
+ * delete a single actor
+ * @param {string} id The id of the actor to be deleted
+ * @return {Promise<ApiResponse>}
+ */
 async function deleteActor(id) {
+  console.log(typeof id)
   return await apiCall('DELETE', `actors/${id}`);
 };
 
+/**
+ * add a new actor to the database
+ * @param {string} name The name of the actor to add
+ * @return {Promise<ApiResponse>}
+ */
 async function newActor(name) {
   name = JSON.stringify({ name });
   return await apiCall('POST', 'actors', name, { 'Content-Type': 'application/json' });
 }
 
+/**
+ * get all the characters that are assigned to the current actor
+ * @param {Actor} actor
+ * @param {string} currentScriptId
+ * @return {Promise<ApiResponse>}
+ */
 async function getCurrentActorCharacters(actor, currentScriptId) {
   return await apiCall('GET', `characters/${currentScriptId}/?actorId=${actor.id}`);
 }
 
+/**
+ * get all characters for the selected script
+ * @param {string} scriptId
+ * @return {Promise<ApiResponse>}
+ */
 async function getCharacters(scriptId) {
   return await apiCall('GET', `characters/${scriptId}`);
 }
 
+/**
+ * assign the selected character to the selected actor
+ * @param {string} characterId
+ * @param {string|null} actorId
+ * @param {string} scriptId
+ * @return {Promise<ApiResponse>}
+ */
 async function assignCharacter(characterId, actorId, scriptId){
   if(actorId === 'unassignedCharacters'){
     actorId = null;
@@ -27,19 +69,39 @@ async function assignCharacter(characterId, actorId, scriptId){
   return await apiCall('POST', `characters/${scriptId}/assignCharacter`, body, { 'Content-Type': 'application/json'})
 }
 
+/**
+ * get the entire script
+ * @param {string} scriptId
+ * @return {Promise<ApiResponse>}
+ */
 async function getScript(scriptId) {
   return await apiCall('GET', 'script/' + scriptId);
 }
 
+/**
+ * get the titles of all the scripts
+ * @return {Promise<ApiResponse>}
+ */
 async function getScriptTitles() {
   return await apiCall('GET', 'scripts/title');
 }
 
+/**
+ * delete the specified script
+ * @param {string} deleteId
+ * @return {Promise<ApiResponse>}
+ */
 async function deleteScript(deleteId) {
   return await apiCall('DELETE', `script/${deleteId}`);
 }
 
+/**
+ * upload the given script
+ * @param {FormData} formData
+ * @return {Promise<{success: boolean, data: any}>}
+ */
 async function uploadScript(formData) {
+  console.log(typeof formData)
   const response = await fetch('/api/script', { method: 'POST', body: formData })
   if (response.ok){
     return {
@@ -64,12 +126,26 @@ async function uploadScript(formData) {
   }
 
 }
-
+/**
+ * post the current position of the actor in the script
+ * @param {number} actorId The id of the current actor
+ * @param {string} scriptId The id of the current script
+ * @param {string} position The actor's current position in the script
+ * @return {Promise<ApiResponse>}
+ */
 async function postPosition(actorId, scriptId, position) {
   const body = JSON.stringify({ actorId, scriptId, position });
   return await apiCall('POST', 'positions', body, { 'Content-Type': 'application/json' });
 }
 
+/**
+ * Calls the api with the given arguments
+ * @param {string} method The given HTTP method
+ * @param {string} uri The uri that comes after /api/
+ * @param {object} body The body of the HTTP request
+ * @param {object} headers The header parameters for the HTTP request
+ * @return {Promise<ApiResponse>}
+ */
 async function apiCall(method, uri, body = null, headers = {}) {
 
   try {

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -5,8 +5,6 @@
  * @property {number} status The status for a failed call
  */
 
-/** @module apiCalls */
-
 /**
  * gets all actors
  * @return {Promise<ApiResponse>}

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -1,11 +1,4 @@
 /**
- * @typedef ApiResponse
- * @property {boolean} success Whether or not the api call went through
- * @property {any} data The data from the successful call, or an error message for a failed call
- * @property {number} status The status for a failed call
- */
-
-/**
  * gets all actors
  * @return {Promise<ApiResponse>}
  */
@@ -152,22 +145,25 @@ async function apiCall(method, uri, body = null, headers = {}) {
     });
     // Set data for successful fetch
     if (response.ok) {
-        return {
-          success: true,
-          data: await response.json()
-      };
+        return new ApiResponse(true, await response.json())
     } else { // Set errors from an unsuccessful fetch request
-      return {
-        success: false,
-        data: 'Error: ' + await response.json(),
-        status: response.status
-      };
+      return new ApiResponse(false, 'Error: ' + await response.json(), response.status)
     }
   } catch (error) { // Set errors from not being able to connect to the server
-    return {
-      success: false,
-      data: 'Network error: ' + error.message
-    };
+    return new ApiResponse(false, 'Network error: ' + error.message)
+  }
+}
+
+class ApiResponse{
+  /**
+   * @param {boolean} success Whether or not the api call went through
+   * @param {any} data The data from the successful call, or an error message for a failed call
+   * @param {number} [status] The status for a failed call
+   */
+  constructor(success, data, status) {
+    this.success = success;
+    this.data = data;
+    this.status = status;
   }
 }
 

--- a/src/repository/actorRepository.js
+++ b/src/repository/actorRepository.js
@@ -1,43 +1,46 @@
 const db = require('./database.js');
 
 /**
- * @typedef Actor
- * @property {number} id Database generated id
- * @property {string} name User entered Actor name
- */
-
-/**@module actorRepo */
-
-
-/**
  * Add a new actor to the database
  * @param {string} name User entered actor name
- * @return {Promise<Actor>}
+ * @return {Promise<Actor>} The new actor object
  */
 async function newActor(name) {
   const result = await db.query(`INSERT INTO actors (name) VALUES ($1) RETURNING ID`, [name.trim()]);
 
-  return { id: result.rows[0].id, name };
+  return new Actor(result.rows[0].id, name);
 }
 
 /**
  * Get all the actors from the database
- * @return {Promise<Array.<Actor>>}
+ * @return {Promise<Array.<Actor>>} Array of all the actor's
  */
 async function getActors() {
   const result = await db.query('SELECT * FROM actors');
 
-  return result.rows.map((actor) => ({ id: actor.id, name: actor.name }));
+  return result.rows.map((actor) => (new Actor(actor.id, actor.name)));
 }
 
 /**
  * Delete a single actor from the database
- * @param {number} id
- * @return {Promise<Actor>}
+ * @param {number} id ID of the actor to delete
+ * @return {Promise<boolean>} Whether the query went through
  */
 async function deleteActor(id) {
   const result = await db.query(`DELETE FROM actors WHERE id = $1 RETURNING *`, [id]);
-  return result.rows[0];
+  return !!result;
+}
+
+/** Actor Class */
+class Actor {
+  /**
+   * @param {number} id Unique actor ID
+   * @param {string} name Actor name
+   */
+  constructor(id, name) {
+    this.id = id;
+    this.name = name;
+  }
 }
 
 module.exports = { newActor, getActors, deleteActor };

--- a/src/repository/actorRepository.js
+++ b/src/repository/actorRepository.js
@@ -1,8 +1,8 @@
 const db = require('./database.js');
 
 /**
- * Add a new actor to the database
- * @param {string} name User entered actor name
+ * Add a new actor
+ * @param {string} name The new actor's name
  * @return {Promise<Actor>} The new actor object
  */
 async function newActor(name) {
@@ -12,7 +12,7 @@ async function newActor(name) {
 }
 
 /**
- * Get all the actors from the database
+ * Get all the actors
  * @return {Promise<Array.<Actor>>} Array of all the actor's
  */
 async function getActors() {
@@ -22,7 +22,7 @@ async function getActors() {
 }
 
 /**
- * Delete a single actor from the database
+ * Delete a single actor
  * @param {number} id ID of the actor to delete
  * @return {Promise<boolean>} Whether the query went through
  */
@@ -31,7 +31,6 @@ async function deleteActor(id) {
   return !!result;
 }
 
-/** Actor Class */
 class Actor {
   /**
    * @param {number} id Unique actor ID

--- a/src/repository/actorRepository.js
+++ b/src/repository/actorRepository.js
@@ -1,19 +1,43 @@
 const db = require('./database.js');
 
+/**
+ * @typedef Actor
+ * @property {number} id Database generated id
+ * @property {string} name User entered Actor name
+ */
+
+/**@module actorRepo */
+
+
+/**
+ * Add a new actor to the database
+ * @param {string} name User entered actor name
+ * @return {Promise<Actor>}
+ */
 async function newActor(name) {
   const result = await db.query(`INSERT INTO actors (name) VALUES ($1) RETURNING ID`, [name.trim()]);
 
   return { id: result.rows[0].id, name };
 }
 
+/**
+ * Get all the actors from the database
+ * @return {Promise<Array.<Actor>>}
+ */
 async function getActors() {
   const result = await db.query('SELECT * FROM actors');
 
   return result.rows.map((actor) => ({ id: actor.id, name: actor.name }));
 }
 
+/**
+ * Delete a single actor from the database
+ * @param {number} id
+ * @return {Promise<Actor>}
+ */
 async function deleteActor(id) {
-  return await db.query(`DELETE FROM actors WHERE id = $1 RETURNING *`, [id]);
+  const result = await db.query(`DELETE FROM actors WHERE id = $1 RETURNING *`, [id]);
+  return result.rows[0];
 }
 
 module.exports = { newActor, getActors, deleteActor };

--- a/src/repository/characterRepository.js
+++ b/src/repository/characterRepository.js
@@ -1,6 +1,13 @@
 const db = require('./database');
 const { Character } = require('../services/scriptParser');
 
+/**
+ * Get all the characters for the current script.
+ * Also can get the characters for a specified actor
+ * @param {string} scriptId ID of the selected script
+ * @param {string | number} actorId optional: ID of the selected actor. Default value of -1 to allow SQL query even when no ID is given
+ * @return {Promise<{Character}>} Character objects indexed by their id
+ */
 async function getCharacters(scriptId, actorId = -1) {
   const result = await db.query(
     `
@@ -10,21 +17,28 @@ async function getCharacters(scriptId, actorId = -1) {
         AND script_id = $2`,
     [actorId, scriptId]
   );
-
   const characters = {};
   result.rows.forEach((c) => characters[c.id.toString()] = new Character(c.name, c.line_count, c.speaks_count, c.id.toString(), c.actor_id));
   return characters;
 
-};
+}
 
+/**
+ * Assign a character to a specified actor.
+ * @param {string} scriptId ID of the selected script
+ * @param {string} characterId ID of the selected character that will be assigned
+ * @param {string} actorId ID of the actor that the character will be assigned to
+ * @return {Promise<boolean>} Whether on to the query went through
+ */
 async function assignCharacter(scriptId, characterId, actorId) {
-  return await db.query(`
+  const result = await db.query(`
     UPDATE characters
     SET actor_id = $1
     WHERE script_id = $2 AND id = $3
     RETURNING *`,
     [actorId, scriptId, characterId]
   );
-};
+  return !!result.rows;
+}
 
 module.exports = { getCharacters, assignCharacter };

--- a/src/repository/dotRepository.js
+++ b/src/repository/dotRepository.js
@@ -2,9 +2,9 @@ const db = require('./database.js');
 
 /**
  * Get ID for a progress dot, creates one if it does not already exist
- * @param {string} scriptId ID of the selected script
- * @param {number} actorId ID of the selected actor
- * @return {Promise<number>} ID of the newly created progress dot
+ * @param {string} scriptId ID of the script that the dot belongs to
+ * @param {number} actorId ID of the actor that the dot belongs to
+ * @return {Promise<number>} ID of the progress dot
  */
 async function getId(scriptId, actorId) {
   const result = await db.query(
@@ -21,7 +21,7 @@ async function getId(scriptId, actorId) {
 
 /**
  * Update the position of the progress dot
- * @param {number} dotId ID of the current progress dot
+ * @param {number} dotId ID of the progress dot
  * @param {string} position New position of the progress dot
  */
 async function set(dotId, position) {
@@ -29,9 +29,9 @@ async function set(dotId, position) {
 }
 
 /**
- * Get all the progress dots for the selected script
- * @param {string} scriptId ID of the selected script
- * @return {Promise<Array.<Dot>>}
+ * Get all the progress dots for the specified script
+ * @param {string} scriptId ID of the script
+ * @return {Promise<Array.<Dot>>} Array of all progress dots for the specified script
  */
 async function getAll(scriptId) {
   const result = await db.query('SELECT id, actor_id, position FROM read_position WHERE script_id = $1', [scriptId]);
@@ -39,7 +39,6 @@ async function getAll(scriptId) {
   return result.rows.map((dot) => (new Dot(dot.id, dot.actor_id, scriptId, dot.position)));
 }
 
-/** Dot Class */
 class Dot {
   /**
    * @param {number} id ID of the progress dot

--- a/src/repository/dotRepository.js
+++ b/src/repository/dotRepository.js
@@ -1,5 +1,11 @@
 const db = require('./database.js');
 
+/**
+ * Get ID for a progress dot, creates one if it does not already exist
+ * @param {string} scriptId ID of the selected script
+ * @param {number} actorId ID of the selected actor
+ * @return {Promise<number>} ID of the newly created progress dot
+ */
 async function getId(scriptId, actorId) {
   const result = await db.query(
     `INSERT INTO read_position (actor_id, script_id, position)
@@ -13,19 +19,40 @@ async function getId(scriptId, actorId) {
   return result.rows[0].id;
 }
 
+/**
+ * Update the position of the progress dot
+ * @param {number} dotId ID of the current progress dot
+ * @param {string} position New position of the progress dot
+ */
 async function set(dotId, position) {
   await db.query(`UPDATE read_position SET position = $2 WHERE id = $1`, [dotId, position]);
 }
 
+/**
+ * Get all the progress dots for the selected script
+ * @param {string} scriptId ID of the selected script
+ * @return {Promise<Array.<Dot>>}
+ */
 async function getAll(scriptId) {
   const result = await db.query('SELECT id, actor_id, position FROM read_position WHERE script_id = $1', [scriptId]);
 
-  return result.rows.map((dot) => ({
-    id: dot.id,
-    actorId: dot.actor_id,
-    scriptId: scriptId,
-    position: dot.position,
-  }));
+  return result.rows.map((dot) => (new Dot(dot.id, dot.actor_id, scriptId, dot.position)));
+}
+
+/** Dot Class */
+class Dot {
+  /**
+   * @param {number} id ID of the progress dot
+   * @param {number} actorId ID of the actor associated with the dot
+   * @param {string} scriptId ID of the selected script
+   * @param {string} position Current position of the dot
+   */
+  constructor(id, actorId, scriptId, position) {
+    this.id = id;
+    this.actorId = actorId;
+    this.scriptId = scriptId;
+    this.position = position;
+  }
 }
 
 module.exports = { getId, set, getAll };

--- a/src/repository/scriptRepository.js
+++ b/src/repository/scriptRepository.js
@@ -45,9 +45,9 @@ async function deleteScript(id) {
 }
 
 /**
- * import the given script, parse it, and store it and it's data in the database
+ * import the given script, parse it, and store it
  * @param {string} filepath The filepath where the new script is located
- * @return {Promise<Script>}
+ * @return {Promise<Script>} Object containing the script's id and title
  */
 async function importScript(filepath) {
   // Add script and characters if it doesn't already exist
@@ -85,10 +85,9 @@ async function importScript(filepath) {
   return new Script(scriptId, title);
 }
 
-/** Script Class */
 class Script {
   /**
-   * @param {number} id Database generated script id
+   * @param {number} id Unique script id
    * @param {string} title Script title
    */
   constructor(id, title) {

--- a/src/repository/scriptRepository.js
+++ b/src/repository/scriptRepository.js
@@ -6,13 +6,30 @@ const ServerError = require('../services/utils');
 const db = require('./database.js');
 const { parseTitle, parseLines, parseCharacters } = require('../services/scriptParser.js');
 
+/**
+ * @typedef Script
+ * @property {number} id Database generated script id
+ * @property {string} title Script title
+ */
 
+/** @module scriptRepo */
+
+/**
+ * get all the script titles
+ * @return {Promise<Array.<Script>>}
+ */
 async function getTitles() {
   const result = await db.query('select id, title from scripts');
 
   return result.rows.map((s) => ({ id: s.id, title: s.title }));
 }
 
+/**
+ * get the specified script
+ * @param {string} scriptDir The path for the script directory
+ * @param {string} id The script ID
+ * @return {Promise<Array<string>>}
+ */
 async function getScript(scriptDir, id) {
   const result = await db.query(
     'select filename from scripts where id = $1 limit 1',
@@ -23,10 +40,20 @@ async function getScript(scriptDir, id) {
   return parseLines(file);
 }
 
+/**
+ * delete the specified script
+ * @param {string} id The script ID
+ * @return {Promise<*>} raw database result, unused
+ */
 async function deleteScript(id) {
   return await db.query('DELETE FROM scripts WHERE id = $1 RETURNING *;', [id]);
 }
 
+/**
+ * import the given script, parse it, and store it and it's data in the database
+ * @param {string} filepath The filepath where the new script is located
+ * @return {Promise<{id: {number}, title: {string}}>}
+ */
 async function importScript(filepath) {
   // Add script and characters if it doesn't already exist
   const file = await fs.readFileAsync(filepath, 'utf8');

--- a/src/repository/scriptRepository.js
+++ b/src/repository/scriptRepository.js
@@ -6,7 +6,8 @@ const ServerError = require('../services/utils');
 const db = require('./database.js');
 const { parseTitle, parseLines, parseCharacters } = require('../services/scriptParser.js');
 
-
+//TODO: Rethink naming to clarify between the Script object that has just title and name, and the script array of strings.
+// This affects naming confusion in the server and on the frontend as well.
 
 /**
  * get all the script titles

--- a/src/services/scriptParser.js
+++ b/src/services/scriptParser.js
@@ -1,5 +1,4 @@
 const ServerError = require('./utils');
-/** @module scriptParser */
 
 /*
 TODO: Add handling for other script formats 
@@ -44,7 +43,7 @@ function parseLines(scriptText) {
 /**
  * Identify the characters in the script and count their lines
  * @param {string} scriptText The entire play script
- * @return {Object.<Character>} characters Object containing Character objects for each character in the play
+ * @return {Object.<Character>} characters Object containing Character objects for each character in the play. Indexed by the character's name
  */
 function parseCharacters(scriptText) {
   const lineChunks = parseLines(scriptText);
@@ -91,22 +90,23 @@ function isName(name) {
   return isUppercase(name) && name.length > 1 && name.length < 20 && !name.match(/(ACT)/);
 }
 
-/**
- * Character Constructor
- * @param {string} name  character's name
- * @param {number} lineCount character's total lines
- * @param {number} speakCount total for how many times the character starts talking
- * @param {number | null} id id from the database
- * @param {number | null} actorId the id of the actor who is assigned to this character
- * @constructor
- */
-function Character(name, lineCount, speakCount, id = null, actorId = null) {
-  this.name = name;
-  this.lineCount = lineCount;
-  this.speakCount = speakCount;
-  this.id = id;
-  this.actorId = actorId;
-
+/** Character Class */
+class Character {
+  /**
+   * Construct a Character object
+   * @param {string} name  character's name
+   * @param {number} lineCount character's total lines
+   * @param {number} speakCount total for how many times the character starts talking
+   * @param {number | null} id id from the database
+   * @param {number | null} actorId the id of the actor who is assigned to this character
+   */
+  constructor(name, lineCount, speakCount, id = null, actorId = null) {
+    this.name = name;
+    this.lineCount = lineCount;
+    this.speakCount = speakCount;
+    this.id = id;
+    this.actorId = actorId;
+  }
 }
 
 module.exports = { Character, parseTitle, parseLines, parseCharacters };

--- a/src/services/scriptParser.js
+++ b/src/services/scriptParser.js
@@ -1,4 +1,5 @@
 const ServerError = require('./utils');
+/** @module scriptParser */
 
 /*
 TODO: Add handling for other script formats 
@@ -13,6 +14,12 @@ ex:'BOB. My name is Bob and these are my lines.'
 This format without the new line between character name and line means that the current algorithm can't identify character names or line counts.
 */
 
+/**
+ * Identify the title within the script
+ * @param {string} scriptText The entire play script
+ * @return {string} The script title
+ * @throws {ServerError} Throws an error if it can't find a title
+ */
 function parseTitle(scriptText) {
   const matches = scriptText.match(/^Title: (.+)$/m);
   if (matches !== null && matches.length === 2) {
@@ -22,6 +29,11 @@ function parseTitle(scriptText) {
   throw new ServerError(452, 'Could not identify a title in the script');
 }
 
+/**
+ * Split up the play script based on a double new line
+ * @param {string} scriptText The entire play script
+ * @return {Array.<string>} Script chunked into sections
+ */
 function parseLines(scriptText) {
 
   return scriptText
@@ -29,6 +41,11 @@ function parseLines(scriptText) {
     .split('\n\n'); // Different character's lines are separated by double \n
 }
 
+/**
+ * Identify the characters in the script and count their lines
+ * @param {string} scriptText The entire play script
+ * @return {Object.<Character>} characters Object containing Character objects for each character in the play
+ */
 function parseCharacters(scriptText) {
   const lineChunks = parseLines(scriptText);
   const characters = {};
@@ -55,16 +72,34 @@ function parseCharacters(scriptText) {
   return characters;
 }
 
-function isUppercase(str) {
-  return str === str.toUpperCase();
+/**
+ * Check if a potential name is all uppercase
+ * @param {string} name a string that may be a character name
+ * @return {boolean}
+ */
+function isUppercase(name) {
+  return name === name.toUpperCase();
 }
 
-// checks if a name is a valid name
+/**
+ * Check if a name is valid
+ * @param {string} name the string that comes before the first dot '.' in a section and may be a character name
+ * @return {boolean}
+ */
+// TODO also exclude 'SCENE'
 function isName(name) {
   return isUppercase(name) && name.length > 1 && name.length < 20 && !name.match(/(ACT)/);
 }
 
-// character object constructor
+/**
+ * Character Constructor
+ * @param {string} name  character's name
+ * @param {number} lineCount character's total lines
+ * @param {number} speakCount total for how many times the character starts talking
+ * @param {number | null} id id from the database
+ * @param {number | null} actorId the id of the actor who is assigned to this character
+ * @constructor
+ */
 function Character(name, lineCount, speakCount, id = null, actorId = null) {
   this.name = name;
   this.lineCount = lineCount;

--- a/src/services/scriptParser.js
+++ b/src/services/scriptParser.js
@@ -90,7 +90,6 @@ function isName(name) {
   return isUppercase(name) && name.length > 1 && name.length < 20 && !name.match(/(ACT)/);
 }
 
-/** Character Class */
 class Character {
   /**
    * Construct a Character object

--- a/src/services/startupChecks.js
+++ b/src/services/startupChecks.js
@@ -5,6 +5,10 @@ const red = "\x1b[31m";
 const bold = "\x1b[1m";
 const reset = "\x1b[0m";
 
+/**
+ * Check that the required environment variables are present when the server is starting.
+ * If an environment variable is missing, log what variable is missing and stop the server
+ */
 function assertEnvVarsPresent() {
   let variables = [
     'DATABASE_URI',

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,4 +1,11 @@
 class ServerError extends Error {
+  /**
+   * Server error to handle internally thrown errors so we can more easily trace them back
+   * @param {number} status The HTTP error status to throw
+   * @param {string} message The message to display with the error
+   * @param {string} log Traceback information for where the error occurred
+   * @constructor
+   */
   constructor(status, message, log) {
     super(message);
     if (!log) {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -3,8 +3,7 @@ class ServerError extends Error {
    * Server error to handle internally thrown errors so we can more easily trace them back
    * @param {number} status The HTTP error status to throw
    * @param {string} message The message to display with the error
-   * @param {string} log Traceback information for where the error occurred
-   * @constructor
+   * @param {string} [log] Traceback information for where the error occurred
    */
   constructor(status, message, log) {
     super(message);


### PR DESCRIPTION
This documentation covers most but not all files. Primary exclusions are the server.js file and the controllers directory. API Documentation is to come using Swagger.

I've also added a script that runs JSdoc to create the documentation in a /docs folder. This makes a nice page at /docs/index.html to look at all the documentation in one place.
`npm run jsdoc`

There is one code change in this PR as well, a variable rename in scriptParser.js in the isUppercase function, I changed the parameter name from 'str' to 'name' to match its use.

This is progress toward issue #53 
Example page:
![Screenshot from 2023-05-25 17-59-20](https://github.com/rcheman/PlayReadingParty/assets/46881905/9ac9f9ad-428e-43ab-b91e-8ce465ec159d)
