### PR TITLE
Adds a redirect to accomodate for nonvalid scriptIDs 

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,7 +12,8 @@ const Header = ({ currentScriptId }) => {
   return (
     <div>
       <header>
-        <h1><Link to={`/${currentScriptId}`} id='titleLink'>Play Reading Party</Link></h1>
+        {/*Links back to the currentScript page if there is a current script*/}
+        <h1><Link to={currentScriptId ? `/${currentScriptId}` : '#'} id='titleLink'>Play Reading Party</Link></h1>
       </header>
     </div>
   );

--- a/src/components/Upload.jsx
+++ b/src/components/Upload.jsx
@@ -37,7 +37,6 @@ const Upload = ({ setCurrentScriptId, scripts, setScripts }) => {
     // set the file as Form Data and send it to the server
     const formData = new FormData();
     formData.append('scriptFormField', file);
-    console.log(formData)
 
     // Upload the script and display any error messages
     const result = await uploadScript(formData);


### PR DESCRIPTION
...that occur from refreshes or deleting a script. Removes an errant console.log

When a script is uploaded we are setting the currentScriptId to 'false' because previously we would set it to null, and that was not prompting a rerender in React. This means that when we delete a script and then refresh we have a currentScriptId of false showing up in the path. 

Also, when we refresh the home page in general, Home's loader is expecting a ScriptId in the parameters and finding none, so it says it is undefined but it's the string 'undefined', so it still tries to create all the Character Assignment components. 

To resolve this, in the loader if the currentScriptID is 'undefined' or 'false', we will return a redirect. This also saves us from trying to load actor and script data that we don't need since we don't have a valid script.

Hopefully this actually closes #57 

![Peek 2023-05-29 18-57](https://github.com/rcheman/PlayReadingParty/assets/46881905/6223b2af-6406-4512-94e0-7e178ce5dc4e)
