### PR TITLE
Openapi

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -45,7 +45,7 @@ paths:
                   example: "Mary Poppins"
                   description: name of the new actor to be added
       responses:
-        200:
+        201:
           description: Successful response
           content:
             application/json:
@@ -213,7 +213,7 @@ paths:
                   type: string
                   format: binary
       responses:
-        200:
+        201:
           description: Successful response
           content:
             application/json:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,399 @@
+openapi: "3.0.2"
+info:
+  title: PlayReadingParty
+  description: "Read plays with your friends"
+  version: "1.0"
+  contact:
+    name: "Play Reading Party"
+    url: "https://playreadingparty.com/"
+paths:
+  /actors:
+    get:
+      tags:
+        - Actor Data
+      summary: "Get all the actor data."
+      operationId: getActors
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                title: Successful response
+                type: array
+                items:
+                  $ref: '#/components/schemas/Actor'
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+    post:
+      tags:
+        - Actor Data
+      summary: "Add a new actor."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: "Mary Poppins"
+                  description: name of the new actor to be added
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Actor'
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+
+  /actors/{actorId}:
+    delete:
+      tags:
+        - Actor Data
+      summary: "Delete an actor"
+      operationId: deleteActor
+      parameters:
+        - $ref: '#/components/parameters/actorId'
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/successfulQueryResponse'
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+  /characters/{scriptId}:
+    get:
+      tags:
+        - Character Data
+      summary: "Get the characters for the specified script. Can filter for a specific actor"
+      operationId: getCharacters
+      parameters:
+        - in: query
+          name: actorId
+          schema:
+            type: integer
+          description: The ID for the actor whose assigned characters should be retrieved
+        - $ref: '#/components/parameters/scriptId'
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Object keys are the unique IDs of the characters.
+                properties:
+                  characterID:
+                    $ref: '#/components/schemas/Character'
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+  /characters/{scriptId}/assignCharacter:
+    post:
+      tags:
+        - Character Data
+      summary: "Assign a character to an actor"
+      operationId: assignCharacter
+      parameters:
+        - $ref: '#/components/parameters/scriptId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                actorId:
+                  $ref: '#/components/schemas/actorId'
+                characterId:
+                  $ref: '#/components/schemas/characterId'
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/successfulQueryResponse'
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+  /positions:
+    post:
+      tags:
+        - Position Data
+      summary: Report the read position of an actor in a script
+      operationId: reportPosition
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                actorId:
+                  $ref: '#/components/schemas/actorId'
+                scriptId:
+                  $ref: '#/components/schemas/scriptId'
+                position:
+                  type: integer
+                  description: the percentage between 0.0 and 1.0 that the user has scrolled through the script
+                  example: 0.7
+      responses:
+        200:
+          description: Successful response
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+  /positions/{scriptId}:
+    get:
+      tags:
+        - Position Data
+      summary: Subscribe to server sent event to get updated positions of other actors
+      operationId: subscribePositions
+      parameters:
+        - $ref: '#/components/parameters/scriptId'
+      responses:
+        200:
+          description: SERVER SENT EVENT
+          content:
+            text/event-stream:
+              schema:
+                type: object
+                properties:
+                  actorId:
+                    $ref: '#/components/schemas/actorId'
+                  scriptId:
+                    $ref: '#/components/schemas/scriptId'
+                  position:
+                    type: integer
+                    description: the percentage between 0.0 and 1.0 that the user has scrolled through the script
+                    example: 0.7
+
+  /script:
+    post:
+      tags:
+        - Script Data
+      summary: Upload a new script file
+      operationId: uploadScript
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                scriptFormField:
+                  type: string
+                  format: binary
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    example: 12
+                    description: Unique Script Id
+                  title:
+                    type: string
+                    example: "The Importance of Being Earnest"
+                    description: Script title
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+  /scripts/title:
+    get:
+      tags:
+        - Script Data
+      summary: Get all the script titles
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      example: 10
+                      description: Unique Script Id
+                    title:
+                      type: string
+                      example: "The Ideal Husband"
+                      description: Script title
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+  /script/{scriptId}:
+    get:
+      tags:
+        - Script Data
+      summary: Get the contents of the entire play script
+      parameters:
+        - $ref: '#/components/parameters/scriptId'
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  example: "LORD DARLINGTON.  My dear Lady Windermere!"
+                  description: chunk of text for a single line
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+    delete:
+      tags:
+        - Script Data
+      summary: Delete the specified script
+      parameters:
+        - $ref: '#/components/parameters/scriptId'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/successfulQueryResponse'
+        500:
+          description: Error Internal Server Error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/500'
+
+
+
+
+
+
+
+
+components:
+
+  parameters:
+    scriptId:
+      name: scriptId
+      in: path
+      description: "Script ID number"
+      schema:
+        type: integer
+      required: true
+    actorId:
+      name: actorId
+      in: path
+      description: "Actor ID number"
+      schema:
+        type: integer
+      required: true
+  schemas:
+    500:
+      title: Server error
+      type: string
+      description: Error from express error handler
+      example: "Express error handler caught unknown middleware error"
+    Actor:
+      title: Actor
+      type: object
+      properties:
+        id:
+          type: integer
+          description: unique actor ID
+          example: 7
+        name:
+          type: string
+          description: the actor's name
+          example: 'Rachel'
+    successfulQueryResponse:
+      title: Successful Query Response
+      type: boolean
+      description: Whether or not the query was successful
+      example: true
+    Character:
+      title: Character
+      type: object
+      properties:
+        name:
+          type: string
+          description: character's name
+          example: "Viola"
+        lineCount:
+          type: integer
+          description: character's total line count
+          example: 120
+        speakCount:
+          type: integer
+          description: character's total count of how many times they start speaking
+          example: 20
+        id:
+          type: string
+          description: Unique character ID
+          example: 8
+        actorId:
+          $ref: '#/components/schemas/actorId'
+    actorId:
+      title: actorId
+      type: integer
+      example: 10
+      description: Unique Actor ID
+    scriptId:
+      title: scriptId
+      type: integer
+      example: 23
+      description: Unique Script ID
+    characterId:
+      title: characterId
+      type: integer
+      example: 23
+      description: Unique character ID
+
+servers:
+  - url: https://playreadingparty.com/api
+    description: Production server
+  - url: http:localhost:3000/api
+    description: Development server

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -47,15 +47,13 @@ async function getCharacters(scriptId) {
 /**
  * assign the selected character to the selected actor
  * @param {string} characterId
- * @param {string|null} actorId
+ * @param {string|null|number} actorId
  * @param {string} scriptId
  * @return {Promise<ApiResponse>}
  */
 async function assignCharacter(characterId, actorId, scriptId){
-  if(actorId === 'unassignedCharacters'){
-    actorId = null;
-  }
-  const body = JSON.stringify({ actorId, characterId })
+  actorId === 'unassignedCharacters' ? actorId = null : actorId = Number(actorId)
+  const body = JSON.stringify({ actorId: actorId, characterId: Number(characterId) })
   return await apiCall('POST', `characters/${scriptId}/assignCharacter`, body, { 'Content-Type': 'application/json'})
 }
 
@@ -123,7 +121,11 @@ async function uploadScript(formData) {
  * @return {Promise<ApiResponse>}
  */
 async function postPosition(actorId, scriptId, position) {
-  const body = JSON.stringify({ actorId, scriptId, position });
+  const body = JSON.stringify({
+    actorId: Number(actorId),
+    scriptId: Number(scriptId),
+    position: Number(position)
+  });
   return await apiCall('POST', 'positions', body, { 'Content-Type': 'application/json' });
 }
 

--- a/src/controllers/dotController.js
+++ b/src/controllers/dotController.js
@@ -5,6 +5,7 @@ const dotIds = {};
 
 async function subscribe(req, res) {
   let { scriptId } = req.params;
+  scriptId = Number(scriptId)
 
   res.writeHead(200, {
     'Cache-Control': 'no-cache',

--- a/src/repository/characterRepository.js
+++ b/src/repository/characterRepository.js
@@ -5,7 +5,7 @@ const { Character } = require('../services/scriptParser');
  * Get all the characters for the current script.
  * Also can get the characters for a specified actor
  * @param {string} scriptId ID of the selected script
- * @param {string | number} actorId optional: ID of the selected actor. Default value of -1 to allow SQL query even when no ID is given
+ * @param {number} actorId optional: ID of the selected actor. Default value of -1 to allow SQL query even when no ID is given
  * @return {Promise<{Character}>} Character objects indexed by their id
  */
 async function getCharacters(scriptId, actorId = -1) {
@@ -26,8 +26,8 @@ async function getCharacters(scriptId, actorId = -1) {
 /**
  * Assign a character to a specified actor.
  * @param {string} scriptId ID of the selected script
- * @param {string} characterId ID of the selected character that will be assigned
- * @param {string} actorId ID of the actor that the character will be assigned to
+ * @param {number} characterId ID of the selected character that will be assigned
+ * @param {number} actorId ID of the actor that the character will be assigned to
  * @return {Promise<boolean>} Whether on to the query went through
  */
 async function assignCharacter(scriptId, characterId, actorId) {

--- a/src/repository/dotRepository.js
+++ b/src/repository/dotRepository.js
@@ -2,7 +2,7 @@ const db = require('./database.js');
 
 /**
  * Get ID for a progress dot, creates one if it does not already exist
- * @param {string} scriptId ID of the script that the dot belongs to
+ * @param {number} scriptId ID of the script that the dot belongs to
  * @param {number} actorId ID of the actor that the dot belongs to
  * @return {Promise<number>} ID of the progress dot
  */
@@ -22,7 +22,7 @@ async function getId(scriptId, actorId) {
 /**
  * Update the position of the progress dot
  * @param {number} dotId ID of the progress dot
- * @param {string} position New position of the progress dot
+ * @param {number} position New position of the progress dot
  */
 async function set(dotId, position) {
   await db.query(`UPDATE read_position SET position = $2 WHERE id = $1`, [dotId, position]);
@@ -30,7 +30,7 @@ async function set(dotId, position) {
 
 /**
  * Get all the progress dots for the specified script
- * @param {string} scriptId ID of the script
+ * @param {number} scriptId ID of the script
  * @return {Promise<Array.<Dot>>} Array of all progress dots for the specified script
  */
 async function getAll(scriptId) {
@@ -43,8 +43,8 @@ class Dot {
   /**
    * @param {number} id ID of the progress dot
    * @param {number} actorId ID of the actor associated with the dot
-   * @param {string} scriptId ID of the selected script
-   * @param {string} position Current position of the dot
+   * @param {number} scriptId ID of the selected script
+   * @param {number} position Current position of the dot
    */
   constructor(id, actorId, scriptId, position) {
     this.id = id;

--- a/src/repository/scriptRepository.js
+++ b/src/repository/scriptRepository.js
@@ -38,7 +38,10 @@ async function getScript(scriptDir, id) {
 /**
  * delete the specified script
  * @param {string} id The script ID
- * @return {Promise<boolean>} Whether or not the query was successful
+ * @return {Promise<object>} Script data
+ * @return {number} object.id The script's unique ID
+ * @return {string} object.title The script's title
+ * @return {string} object.filename The script's filename
  */
 async function deleteScript(id) {
   const result = await db.query('DELETE FROM scripts WHERE id = $1 RETURNING *;', [id]);

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ const ServerError = require('./services/utils.js');
 
 require('./services/startupChecks').assert();
 
+
 const app = express();
 app.disable('x-powered-by');
 
@@ -58,7 +59,7 @@ app.get('/api/actors', actorController.getActors, (req, res) => {
 
 // add a new actor to the db, return the actor object
 app.post('/api/actors', actorController.newActor, (req, res) => {
-  return res.status(201).json(res.locals.actor);
+  return res.status(200).json(res.locals.actor);
 });
 
 // delete an actor from the database based on their id

--- a/src/server.js
+++ b/src/server.js
@@ -23,7 +23,7 @@ app.use(express.static(path.resolve(__dirname, '../public')));
 
 // uploads a new script
 app.post('/api/script', scriptController.saveScript, scriptController.importScript, (req, res) => {
-  return res.status(200).json({ id: res.locals.id, title: res.locals.title });
+  return res.status(201).json({ id: res.locals.id, title: res.locals.title });
 });
 
 // returns a list of all the script titles
@@ -59,7 +59,7 @@ app.get('/api/actors', actorController.getActors, (req, res) => {
 
 // add a new actor to the db, return the actor object
 app.post('/api/actors', actorController.newActor, (req, res) => {
-  return res.status(200).json(res.locals.actor);
+  return res.status(201).json(res.locals.actor);
 });
 
 // delete an actor from the database based on their id


### PR DESCRIPTION
This adds openapi documentation for our API. This documentation type is compatible with [SwaggerUI](https://swagger.io/tools/swagger-ui/), although it is not currently implemented. At this point, I think we don't want to be hosting our documentation yet and there is a WebStorm plugin to be able to view the UI version if we want to. This is certainly something we can add later if we would like though. To view the UI without the plugin, use [Swagger Editor](https://editor.swagger.io/) and put in the openapi.yaml file. 

Progress on #53 

This also updates the types for some variables to be passed as Numbers instead of strings.

![Screenshot from 2023-05-30 12-08-07](https://github.com/rcheman/PlayReadingParty/assets/46881905/1e07b626-4497-4bf4-9d6c-2c3e639f3940)
