### PR TITLE
Compress /public files ahead of time so they don't need to be compressed on each request

### DIFF
--- a/deploy/roles/nginx/files/playreading.conf
+++ b/deploy/roles/nginx/files/playreading.conf
@@ -36,15 +36,9 @@ server {
     quic_retry on;
     ssl_early_data on;
 
-    # Compress responses with gzip
-    gzip on;
-    gzip_vary on;
-    gzip_comp_level 9; # Max compression
-    gzip_min_length 1000;
-    gzip_proxied expired no-cache no-store private auth;
-    gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/x-javascript application/xml;
-    gzip_proxied any; # Compress responses from node application server too
-    #gzip_static on; # Send compressed versions of files on disk if they exist (ex: main.js.gz). Todo Plugin not currently installed for nginx-quic.
+    gzip_static on; # Send compressed versions of files on disk if they exist (ex: main.js.gz).
+
+    root /var/www/playreading/public;
 
     location / {
         server_tokens off;
@@ -67,6 +61,15 @@ server {
         server_tokens off;
         # required for browsers to direct them into quic port
         add_header Alt-Svc 'h3=":$server_port"; ma=86400';
+
+        # Compress responses with gzip
+        gzip on;
+        gzip_vary on;
+        gzip_comp_level 6; # medium compression
+        gzip_min_length 1000;
+        gzip_proxied expired no-cache no-store private auth;
+        gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/x-javascript application/xml;
+        gzip_proxied any; # Compress responses from node application server too
 
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;

--- a/deploy/roles/web/handlers/main.yaml
+++ b/deploy/roles/web/handlers/main.yaml
@@ -1,11 +1,18 @@
 ---
 
+# gzip files for nginx's gzip_static
+- name: gzip files
+  command: "{{ item }}"
+  loop:
+    - "find /var/www/playreading/public -name '*.gz' -exec rm {} ;"
+    - "find /var/www/playreading/public -type f ( -name '*.css' -o -name '*.js' -o -name '*.html' ) -exec gzip --best --keep {} ;"
+
+- name: fix selinux permissions
+  command: restorecon -R /var/www/playreading
+
 - name: restart application
   systemd:
     name: playreading.service
     daemon_reload: yes
     state: restarted
     enabled: yes
-
-- name: fix selinux permissions
-  command: restorecon -R /var/www/playreading

--- a/deploy/roles/web/tasks/main.yaml
+++ b/deploy/roles/web/tasks/main.yaml
@@ -30,13 +30,16 @@
     rsync_opts:
       - "--chmod=Dg+x,u+w,Fog-wx,+r"
       - "--chown=root:root"
+      # excludes generated gzip files from being deleted and getting detected as a change
+      - "--filter='P *.gz'"
   loop:
     - ../public
     - ../src
     - ../node_modules
   notify:
-      - fix selinux permissions
-      - restart application
+    - gzip files
+    - fix selinux permissions
+    - restart application
 
 - name: Copy application service file
   copy:


### PR DESCRIPTION
This uses nginx's [gzip_static](https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html) directive to send compressed versions of our static files if they already exist on disk instead of compressing them on demand on every request (which slows down the response).  
Deployment now has a new task which compresses css/js/html files so that they're ready for this.  

For example, here are the generated .gz files corresponding to the html and js files in `public`
```
[root@fedora-playreading ~]# ls -hal /var/www/playreading/public
...
-rw-r--r--. 1 root root  480 May 30 12:59 index.html
-rw-r--r--. 1 root root  284 May 30 12:59 index.html.gz
...
-rw-r--r--. 1 root root 297K May 29 19:44 main.js
-rw-r--r--. 1 root root  92K May 29 19:44 main.js.gz
```